### PR TITLE
fix: skip composer scripts during CI dependency install

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install dependencies
         run: |
           composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+          composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-scripts
 
       - name: List Installed Dependencies
         run: composer show -D

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" "nesbot/carbon:${{ matrix.carbon }}" --no-interaction --no-update
+          composer require 'laravel/framework:${{ matrix.laravel }}' 'orchestra/testbench:${{ matrix.testbench }}' 'nesbot/carbon:${{ matrix.carbon }}' --no-interaction --no-update
           composer update --${{ matrix.stability }} --prefer-dist --no-interaction --no-scripts
 
       - name: List Installed Dependencies

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -19,10 +19,10 @@ jobs:
         include:
           - laravel: 9.*
             testbench: 7.*
-            carbon: ^2.63
+            carbon: '>=2.63'
           - laravel: 10.*
             testbench: 8.*
-            carbon: ^2.63
+            carbon: '>=2.63'
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 


### PR DESCRIPTION
## Summary
- add `--no-scripts` to the `composer update` step in `run-tests` workflow
- prevent `post-autoload-dump` from failing in the Laravel 10 + prefer-lowest matrix before tests run
- keep test execution unchanged (`vendor/bin/pest` still runs in the next step)